### PR TITLE
ci(update-java): convert to reusable workflow

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -3,12 +3,7 @@
 # SPDX-License-Identifier: MIT
 name: update-java
 on:
-  schedule:
-    - cron: "0 3 * * *"
-  push:
-    branches:
-      - ci/auto-update-java
-      - ci/auto-update
+  workflow_call:
 jobs:
   update-java:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Convert the update-java workflow from a scheduled/push-triggered
workflow to a reusable workflow_call trigger.

- Remove schedule trigger (cron: "0 3 * * *")
- Remove push triggers for ci/auto-update-java and ci/auto-update branches
- Add workflow_call trigger to allow calling from other workflows