### PR TITLE
ci(update-java): fix workflow secrets and context variables

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -4,6 +4,9 @@
 name: update-java
 on:
   workflow_call:
+    secrets:
+      gradle_encryption_key:
+        required: true
 jobs:
   update-java:
     runs-on: ubuntu-24.04
@@ -12,8 +15,8 @@ jobs:
       contents: read
       packages: read
     env:
-      ORG_GRADLE_PROJECT_ghUsername: ${{ secrets.GITHUB_ACTOR }}
-      ORG_GRADLE_PROJECT_ghPassword: ${{ secrets.GITHUB_TOKEN }}
+      ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
+      ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -27,7 +30,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5.0.0
         with:
           gradle-version: current
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-encryption-key: ${{ secrets.gradle_encryption_key }}
       - run: gradle wrapper --write-locks
         name: set new wrapper
       - run: find . -name '*gradle.lockfile' -delete


### PR DESCRIPTION
Fix the update-java reusable workflow to properly handle secrets and
use correct GitHub context variables.

- Add gradle_encryption_key as required workflow_call secret input
- Replace secrets.GITHUB_ACTOR with github.actor context variable
- Replace secrets.GITHUB_TOKEN with github.token context variable
- Use lowercase secrets.gradle_encryption_key to match input name