### PR TITLE
ci(update-java): use secrets instead of inputs for gradle encryption key

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5.0.1
         with:
           gradle-version: current
-          cache-encryption-key: ${{ inputs.gradle_encryption_key }}
+          cache-encryption-key: ${{ secrets.gradle_encryption_key }}
       - run: gradle wrapper --write-locks
         name: set new wrapper
       - run: find . -name '*gradle.lockfile' -delete


### PR DESCRIPTION
Fix the gradle cache encryption key reference in the update-java workflow.

- Change from `inputs.gradle_encryption_key` to `secrets.gradle_encryption_key`
- This correctly retrieves the encryption key from repository secrets
