### PR TITLE
ci: add ktlint workflow for Kotlin code linting

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -6,6 +6,7 @@ on: [workflow_call]
 jobs:
   check:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-java@v5.2.0

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright © 2024, 2026 Caleb Cushing
 #
 # SPDX-License-Identifier: MIT
-name: license
+name: ktlint
 on: [workflow_call]
 jobs:
   check:

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright © 2024, 2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+name: license
+on: [workflow_call]
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: asdf-vm/actions/plugins-add@v4.0.1
+      - run: asdf install ktlint
+      - run: ktlint '*.gradle.kts' '**/*.gradle.kts'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright © 2024, 2026 Caleb Cushing
 #
 # SPDX-License-Identifier: MIT
-name: format
+name: prettier
 on: [push, workflow_call]
 jobs:
   check:


### PR DESCRIPTION
Add a new GitHub Actions workflow to run ktlint on Gradle Kotlin scripts.

The workflow:
- Triggers on workflow_call for reusable workflow support
- Runs on ubuntu-24.04
- Sets up Java 21 with Temurin distribution
- Installs ktlint via asdf
- Lints all *.gradle.kts files