### PR TITLE
ci: standardize GitHub Actions secret names to uppercase

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -10,9 +10,9 @@ on:
         description: "Java version to use"
         default: 25
     secrets:
-      gradle_encryption_key:
+      GRADLE_ENCRYPTION_KEY:
         required: true
-      merge_pat:
+      MERGE_PAT:
         required: true
 jobs:
   update:
@@ -37,7 +37,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5.0.2
         with:
           gradle-version: current
-          cache-encryption-key: ${{ secrets.gradle_encryption_key }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - run: gradle wrapper --write-locks
         name: set new wrapper
       - run: find . -name '*gradle.lockfile' -delete
@@ -55,8 +55,8 @@ jobs:
         with:
           title: "chore(deps): java"
           branch: deps/update-java
-          token: ${{ secrets.merge_pat }}
+          token: ${{ secrets.MERGE_PAT }}
       - run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
         if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
         env:
-          GH_TOKEN: ${{ secrets.merge_pat }}
+          GH_TOKEN: ${{ secrets.MERGE_PAT }}

--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -8,7 +8,6 @@ on:
       java-version:
         type: number
         description: "Java version to use"
-        required: true
         default: 25
     secrets:
       gradle_encryption_key:


### PR DESCRIPTION
Standardize GitHub Actions secret names to follow uppercase convention:
- `gradle_encryption_key` → `GRADLE_ENCRYPTION_KEY`
- `merge_pat` → `MERGE_PAT`

Also removes the `required: true` constraint from the `java-version` workflow input since it has a default value.