### PR TITLE
ci(renovate): update automerge strategy and add maven workflow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,5 +5,3 @@
 # SPDX-License-Identifier: MIT
 
 asdf install
-PATH="./.share/bin:$PATH"
-export PATH

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2024 - 2026 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
 //
 // SPDX-License-Identifier: CC0-1.0
 
@@ -8,7 +8,14 @@
   dependencyDashboard: true,
   timezone: "UTC",
   platformAutomerge: true,
-  automergeStrategy: "rebase",
+  automergeStrategy: "squash",
+  // Rebase whenever PR falls behind base branch to keep them mergeable
+  rebaseWhen: "behind-base-branch",
+  // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
+  // Squash merges break subtree history
+  ignorePaths: [".share/**", ".agents/**"],
+  // Remove the 'controls' section from PR body to avoid config noise in squash commits
+  prBodyTemplate: "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
   hostRules: [
     {
       hostType: "maven",
@@ -17,44 +24,31 @@
   ],
   packageRules: [
     {
+      matchManagers: ["maven"],
+      matchUpdateTypes: ["major", "minor", "patch"],
+      automerge: true,
+    },
+    {
       // Python deps via uv: Run daily at 03:00 UTC (after update-java)
       schedule: ["* 3 * * *"],
       matchManagers: ["pep621"],
       automerge: true,
     },
-    // 1. Baseline: Disable ALL Gradle updates (minor/patch/pin/digest)
-    // This effectively ignores libs.versions.toml and build.gradle.kts for non-major updates.
     {
-      matchManagers: ["gradle", "gradle-wrapper"],
-      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
-      enabled: false,
-    },
-    // 2. Goal A: Notify on Major updates (excluding wrapper, as requested)
-    // This will re-enable Major updates for TOML/Build files so you get a PR.
-    {
-      // remember to sync with update-java
-      // Runs during the 04:00 UTC hour daily (scheduled after update-java at 03:00)
-      schedule: ["* 4 * * *"],
-      matchManagers: ["gradle"],
-      // Open PRs for MAJOR updates only; minor/patch are handled elsewhere
-      matchUpdateTypes: ["major"],
-      automerge: false,
-    },
-    // 3. Goal B: Settings Exception (Develocity & Plugins)
-    // Re-enable everything for settings files and automerge them.
-    {
-      // Ensure Gradle plugin versions in settings files are considered
-      // Match all Java update types; run weekly and not concurrently with dev deps
-      // Weekly on Wednesday during the 05:00 UTC hour (devDependencies window is 04:00)
-      schedule: ["* 5 * * 3"],
-      matchManagers: ["gradle"],
-      matchFileNames: ["**/settings.gradle", "**/settings.gradle.kts"],
-      matchUpdateTypes: ["major", "minor", "patch"],
+      matchManagers: ["pyenv"],
       automerge: true,
     },
     {
       matchManagers: ["github-actions"],
       automerge: true,
+    },
+    {
+      // Pin xenoterracide org actions to commit SHAs for build reproducibility
+      // Only these get digest pins; other actions get normal version tag updates
+      matchManagers: ["github-actions"],
+      matchDepNames: ["xenoterracide/**"],
+      automerge: true,
+      pinDigests: true,
     },
     {
       // Run every Wednesday

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+
+name: maven
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        type: number
+        description: "Java version to use"
+        default: 25
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+      - run: ./mvnw verify --batch-mode --fail-at-end
+        env:
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Change automerge strategy from rebase to squash
- Add rebaseWhen: behind-base-branch to keep PRs mergeable
- Add ignorePaths for subtrees (.share/**, .agents/**)
- Customize prBodyTemplate to remove controls section
- Simplify packageRules for gradle, maven, and github-actions
- Pin xenoterracide org actions to commit SHAs
- Add new maven.yml workflow for Maven builds
- Remove PATH export from .envrc
- Fix copyright year format in renovate.json5
