### PR TITLE
build: rename package to @xenoterracide/github and update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
-  "name": "github",
+  "name": "@xenoterracide/github",
   "packageManager": "yarn@4.13.0",
   "private": true,
   "license": "MIT",
-  "workspaces": [
-    ".share/node/*"
-  ],
   "devDependencies": {
     "@prettier/plugin-xml": "^3.4.2",
     "git-conventional-commits": "^2.8.0",
@@ -18,8 +15,16 @@
   },
   "scripts": {
     "contribute": "uv sync --frozen && git config core.hooksPath .share/git/hooks",
-    "merge:copilot": "yarn workspace merge run merge:copilot",
-    "merge:junie": "yarn workspace merge run merge:junie",
-    "merge:kimi": "yarn workspace merge run merge:kimi"
+    "lint": "yarn lint:prettier && yarn lint:reuse",
+    "lint:prettier": "prettier --ignore-unknown --cache --check '**'",
+    "lint:reuse": "yarn reuse lint",
+    "merge:copilot": "cd .share && yarn workspace merge run merge:copilot",
+    "merge:junie": "cd .share && yarn workspace merge run merge:junie",
+    "merge:kimi": "cd .share && yarn workspace merge run merge:kimi",
+    "precontribute": "yarn setup:corepack && yarn setup:yarn",
+    "reuse": "uv run --frozen --group dev reuse",
+    "setup:corepack": "npm install -g corepack && corepack enable",
+    "setup:yarn": "yarn install --immutable && cd .share && yarn install --immutable",
+    "test": "yarn workspaces foreach --all run test"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xenoterracide/github@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@xenoterracide/github@workspace:."
+  dependencies:
+    "@prettier/plugin-xml": "npm:^3.4.2"
+    git-conventional-commits: "npm:^2.8.0"
+    lint-staged: "npm:^16.2.1"
+    prettier: "npm:^3.6.2"
+    prettier-plugin-java: "npm:^2.7.5"
+    prettier-plugin-properties: "npm:^0.3.0"
+    prettier-plugin-toml: "npm:^2.0.6"
+    rimraf: "npm:^6.1.2"
+  languageName: unknown
+  linkType: soft
+
 "@xml-tools/parser@npm:^1.0.11":
   version: 1.0.11
   resolution: "@xml-tools/parser@npm:1.0.11"
@@ -299,21 +314,6 @@ __metadata:
   checksum: 10c0/15e2bd7e6aaeb4697a351e66f66d51f62badbb26a8c356fae5475715d49c6fa0e1672e42bebf11416215317c0ca52eae9ce1c8b94ee8cb59819f76393c1b665e
   languageName: node
   linkType: hard
-
-"github@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "github@workspace:."
-  dependencies:
-    "@prettier/plugin-xml": "npm:^3.4.2"
-    git-conventional-commits: "npm:^2.8.0"
-    lint-staged: "npm:^16.2.1"
-    prettier: "npm:^3.6.2"
-    prettier-plugin-java: "npm:^2.7.5"
-    prettier-plugin-properties: "npm:^0.3.0"
-    prettier-plugin-toml: "npm:^2.0.6"
-    rimraf: "npm:^6.1.2"
-  languageName: unknown
-  linkType: soft
 
 "glob@npm:^13.0.3":
   version: 13.0.6


### PR DESCRIPTION
Rename package from `github` to `@xenoterracide/github` and update
associated lockfile entry.

Remove `workspaces` configuration from root `package.json`.

Update merge scripts to run from `.share` directory.

Add `lint`, `lint:prettier`, `lint:reuse`, `precontribute`, `reuse`,
`setup:corepack`, `setup:yarn`, and `test` scripts.