### PR TITLE
ci(maven): rename build job to maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
         description: "Java version to use"
         default: 25
 jobs:
-  build:
+  maven:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
Rename the job ID from `build` to `maven` to align with the workflow name.