### PR TITLE
ci(renovate): change automerge strategy to rebase and use pinGitHubActionDigests helper

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   dependencyDashboard: true,
   timezone: "UTC",
   platformAutomerge: true,
-  automergeStrategy: "squash",
+  automergeStrategy: "rebase",
   // Rebase whenever PR falls behind base branch to keep them mergeable
   rebaseWhen: "behind-base-branch",
   // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
@@ -47,8 +47,8 @@
       // Only these get digest pins; other actions get normal version tag updates
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
+      extends: ["helpers:pinGitHubActionDigests"],
       automerge: true,
-      pinDigests: true,
     },
     {
       // Run every Wednesday


### PR DESCRIPTION
Change Renovate automerge strategy from "squash" to "rebase" to maintain
linear commit history when auto-merging dependency updates.

Replace the deprecated `pinDigests: true` configuration with the recommended
`extends: ["helpers:pinGitHubActionDigests"]` for pinning GitHub Action digests
in the xenoterracide organization repositories.
