### PR TITLE
ci: consolidate yarn workflow jobs into single check job

### DIFF
--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -5,45 +5,19 @@
 name: yarn
 on: [workflow_call]
 jobs:
-  test:
+  check:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: &checkout actions/checkout@v6.0.2
-      - uses: &node-corepack actions/setup-node@v6.3.0
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
           package-manager-cache: false
-      - run: &corepack corepack enable
-      - uses: &node-yarn actions/setup-node@v6.3.0
+      - run: corepack enable
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
           cache: "yarn"
-      - run: &install yarn install --immutable --inline-builds --check-resolutions
-      - run: yarn test
-  eslint:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: *checkout
-      - uses: *node-corepack
-      - run: *corepack
-      - uses: *node-yarn
-        with:
-          node-version: 24
-          cache: "yarn"
-      - run: &install
-      - run: yarn exec eslint .
-  prettier:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: *checkout
-      - uses: *node-corepack
-      - run: *corepack
-      - uses: *node-yarn
-        with:
-          node-version: 24
-          cache: "yarn"
-      - run: &install
-      - run: yarn exec prettier --ignore-unknown --check '**'
+      - run: yarn install --immutable --inline-builds --check-resolutions
+      - run: yarn check


### PR DESCRIPTION
Consolidate the separate `test`, `eslint`, and `prettier` jobs into a
single `check` job in the yarn workflow. This simplifies the workflow by
removing redundant setup steps and YAML anchors, and aligns with the
pattern of running all checks under a unified `yarn check` command.