### PR TITLE
ci: update node-version to 24.14.1 in workflows

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.14
+          node-version: 24.14.1
           package-manager-cache: false
       - run: corepack enable
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.14
+          node-version: 24.14.1
           cache: "yarn"
       - run: yarn install --immutable --inline-builds --check-resolutions
       - run: yarn exec prettier --ignore-unknown --check '**'

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24
+          node-version: 24.14.1
           package-manager-cache: false
       - run: corepack enable
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "yarn"
       - run: yarn install --immutable --inline-builds --check-resolutions
       - run: yarn check


### PR DESCRIPTION
- Update Node.js version in prettier.yml from 24.14 to 24.14.1
- Update Node.js version in yarn.yml from 24 to 24.14.1