### PR TITLE
ci(node-cli): add prettier version check

### DIFF
--- a/.github/workflows/node-cli.yml
+++ b/.github/workflows/node-cli.yml
@@ -29,3 +29,4 @@ jobs:
       - run: corepack yarn install --immutable
       - run: corepack yarn exec git-conventional-commits --version
       - run: corepack yarn exec lint-staged --version
+      - run: corepack yarn exec prettier --version


### PR DESCRIPTION
Add a step to verify the installed Prettier version in the node-cli workflow.

This ensures that the Prettier formatter is available and its version is
visible in CI logs, aiding debugging and reproducibility.