### PR TITLE
ci(github): simplify asdf setup and remove redundant cache

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -13,6 +13,5 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: asdf-vm/actions/plugins-add@v4.0.1
-      - run: asdf install ktlint
+      - uses: asdf-vm/actions/install@v4.0.1
       - run: ktlint '*.gradle.kts' '**/*.gradle.kts'

--- a/.github/workflows/node-cli.yml
+++ b/.github/workflows/node-cli.yml
@@ -12,21 +12,13 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/cache@v5
         with:
-          path: |
-            ~/.asdf/downloads
-            ~/.asdf/installs
-            ~/.asdf/plugins
-          key: asdf-${{ runner.os }}-${{ hashFiles('.tool-versions') }}
-          restore-keys: asdf-${{ runner.os }}-
-      - uses: actions/cache@v5
-        with:
           path: ~/.local/share/yarn/berry/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-${{ runner.os }}-
-      - uses: asdf-vm/actions/plugins-add@v4.0.1
-      - run: asdf install nodejs
+      - uses: asdf-vm/actions/install@v4.0.1
       - run: corepack enable
-      - run: corepack yarn install --immutable
-      - run: corepack yarn exec git-conventional-commits --version
-      - run: corepack yarn exec lint-staged --version
-      - run: corepack yarn exec prettier --version
+      - run: asdf reshim nodejs
+      - run: yarn install --immutable
+      - run: yarn exec git-conventional-commits --version
+      - run: yarn exec lint-staged --version
+      - run: yarn exec prettier --version


### PR DESCRIPTION
Replace the separate `asdf-vm/actions/plugins-add` and `asdf install`
steps with the combined `asdf-vm/actions/install` action. This reduces
workflow verbosity and delegates plugin management to the action.

In `node-cli.yml`, remove the dedicated asdf cache step since the
`install` action handles caching internally. Also remove `corepack`
from yarn command prefixes and add `asdf reshim nodejs` after
`corepack enable` so that yarn is available on PATH.

- ktlint.yml: use `asdf-vm/actions/install` instead of plugins-add + install
- node-cli.yml: use `asdf-vm/actions/install`, drop asdf cache, drop
  corepack prefix from yarn commands, add `asdf reshim nodejs`

Co-authored-by: Kimi <kimi@moonshot.localhost>
