### PR TITLE
ci(node-cli): add asdf cache and pin cache action version

### DIFF
--- a/.github/workflows/node-cli.yml
+++ b/.github/workflows/node-cli.yml
@@ -10,7 +10,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6.0.3
-      - uses: actions/cache@v5
+      - uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/.asdf/downloads
+            ~/.asdf/installs
+            ~/.asdf/plugins
+          key: asdf-${{ runner.os }}-${{ hashFiles('.tool-versions') }}
+          restore-keys: asdf-${{ runner.os }}-
+      - uses: actions/cache@v5.0.5
         with:
           path: ~/.local/share/yarn/berry/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Add caching for asdf downloads, installs, and plugins in the node-cli
workflow. Pin the actions/cache version to 5.0.5 for both the new asdf
cache and the existing yarn cache.