### PR TITLE
ci(github): fix asdf caching by caching entire ~/.asdf directory

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -13,5 +13,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - uses: actions/cache@v5.0.5
+        with:
+          path: ~/.asdf
+          key: asdf-${{ runner.os }}-${{ hashFiles('.tool-versions') }}
+          restore-keys: asdf-${{ runner.os }}-
       - uses: asdf-vm/actions/install@v4.0.1
       - run: ktlint '*.gradle.kts' '**/*.gradle.kts'

--- a/.github/workflows/node-cli.yml
+++ b/.github/workflows/node-cli.yml
@@ -12,10 +12,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - uses: actions/cache@v5.0.5
         with:
-          path: |
-            ~/.asdf/downloads
-            ~/.asdf/installs
-            ~/.asdf/plugins
+          path: ~/.asdf
           key: asdf-${{ runner.os }}-${{ hashFiles('.tool-versions') }}
           restore-keys: asdf-${{ runner.os }}-
       - uses: actions/cache@v5.0.5


### PR DESCRIPTION
Fix asdf caching in workflows that use `asdf-vm/actions/install`.

The `asdf-vm/actions/install@v4` action installs the asdf binary to `~/.asdf/bin` and sets `ASDF_DIR` and `ASDF_DATA_DIR` to `~/.asdf`. Caching only specific subdirectories (`downloads`, `installs`, `plugins`) fails because:

- `downloads` may not exist after install (e.g., nodejs plugin uses prebuilt binaries)
- the asdf binary and shims are not cached at all, so they're recreated every run

Cache the entire `~/.asdf` directory to include the binary, shims, plugins, and installs. Also add caching to `ktlint.yml` which was missing it entirely.