### PR TITLE
docs: clarify purpose of node-cli workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ All PRs must pass these GitHub Actions workflows.
 
 1. **prettier** (`prettier.yml`): Prettier formatting check on Ubuntu 24.04 with Node.js 24.14.1
 2. **license** (`license.yml`): REUSE compliance verification using `uv run --frozen --group dev reuse lint`
-3. **node-cli** (`node-cli.yml`): Smoke test for Yarn-managed CLI tools (prettier, lint-staged, git-conventional-commits)
+3. **node-cli** (`node-cli.yml`): Smoke test for the asdf Node.js toolchain. Verifies that updates to the Node.js binary do not break developer tools installed via Yarn (`prettier`, `lint-staged`, `git-conventional-commits`).
 4. **ktlint** (`ktlint.yml`): Kotlin formatting check for Gradle scripts
 5. **maven** (`maven.yml`): Reusable Maven build workflow
 6. **yarn** (`yarn.yml`): Reusable Yarn check workflow (runs `yarn check`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,9 @@ All PRs must pass these GitHub Actions workflows.
 
 **Root workflows** (`.github/workflows/`):
 
-1. **prettier** (`prettier.yml`): Prettier formatting check on Ubuntu 24.04 with Node.js 24.14.1
+1. **prettier** (`prettier.yml`): Prettier formatting check on Ubuntu 24.04 with Node.js 24.14.1 (installed via `actions/setup-node`)
 2. **license** (`license.yml`): REUSE compliance verification using `uv run --frozen --group dev reuse lint`
-3. **node-cli** (`node-cli.yml`): Smoke test for the asdf Node.js toolchain. Verifies that updates to the Node.js binary do not break developer tools installed via Yarn (`prettier`, `lint-staged`, `git-conventional-commits`).
+3. **node-cli** (`node-cli.yml`): Smoke test for the asdf Node.js toolchain. Unlike `prettier.yml`, this workflow installs Node.js via `asdf-vm/actions/install` to mirror local developer environments. It verifies that updates to the Node.js binary (driven by `.tool-versions`) do not break developer tools installed via Yarn (`prettier`, `lint-staged`, `git-conventional-commits`).
 4. **ktlint** (`ktlint.yml`): Kotlin formatting check for Gradle scripts
 5. **maven** (`maven.yml`): Reusable Maven build workflow
 6. **yarn** (`yarn.yml`): Reusable Yarn check workflow (runs `yarn check`)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Reusable GitHub Actions workflows for CI/CD automation.
 
 ## Available Workflows
 
-| Workflow        | File              | Purpose                                   |
-| --------------- | ----------------- | ----------------------------------------- |
-| **Prettier**    | `prettier.yml`    | Code formatting check (Prettier)          |
-| **License**     | `license.yml`     | REUSE compliance verification             |
-| **Node CLI**    | `node-cli.yml`    | Smoke test yarn-managed Node.js CLI tools |
-| **Update Java** | `update-java.yml` | Automated Java/Gradle dependency updates  |
+| Workflow        | File              | Purpose                                                                                                                                                                               |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Prettier**    | `prettier.yml`    | Code formatting check (Prettier)                                                                                                                                                      |
+| **License**     | `license.yml`     | REUSE compliance verification                                                                                                                                                         |
+| **Node CLI**    | `node-cli.yml`    | Smoke test for asdf Node.js toolchain — ensures updates to the Node.js binary do not break developer tools installed via Yarn (`prettier`, `lint-staged`, `git-conventional-commits`) |
+| **Update Java** | `update-java.yml` | Automated Java/Gradle dependency updates                                                                                                                                              |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Reusable GitHub Actions workflows for CI/CD automation.
 
 ## Available Workflows
 
-| Workflow        | File              | Purpose                                                                                                                                                                               |
-| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Prettier**    | `prettier.yml`    | Code formatting check (Prettier)                                                                                                                                                      |
-| **License**     | `license.yml`     | REUSE compliance verification                                                                                                                                                         |
-| **Node CLI**    | `node-cli.yml`    | Smoke test for asdf Node.js toolchain — ensures updates to the Node.js binary do not break developer tools installed via Yarn (`prettier`, `lint-staged`, `git-conventional-commits`) |
-| **Update Java** | `update-java.yml` | Automated Java/Gradle dependency updates                                                                                                                                              |
+| Workflow        | File              | Purpose                                                                                                                                                                                                                                                                  |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Prettier**    | `prettier.yml`    | Code formatting check (Prettier)                                                                                                                                                                                                                                         |
+| **License**     | `license.yml`     | REUSE compliance verification                                                                                                                                                                                                                                            |
+| **Node CLI**    | `node-cli.yml`    | Smoke test for the asdf Node.js toolchain. Installs Node.js via `asdf-vm/actions/install` (mirroring local dev environments) to verify that `.tool-versions` updates do not break Yarn-installed developer tools (`prettier`, `lint-staged`, `git-conventional-commits`) |
+| **Update Java** | `update-java.yml` | Automated Java/Gradle dependency updates                                                                                                                                                                                                                                 |
 
 ## Usage
 


### PR DESCRIPTION
- README.md: expand Node CLI workflow purpose to explain it uses asdf (mirroring local dev environments) to verify .tool-versions updates do not break Yarn-installed developer tools
- AGENTS.md: contrast node-cli (asdf-vm/actions/install) with prettier (actions/setup-node) so the reason for the separate smoke test is clear